### PR TITLE
Entra ID rebranding

### DIFF
--- a/components/azure-timeseriesinsights/tsi-eventhubs-arm-template.json
+++ b/components/azure-timeseriesinsights/tsi-eventhubs-arm-template.json
@@ -120,14 +120,14 @@
         "type": "array",
         "defaultValue": [],
         "metadata": {
-          "description": "A list of object ids of the users or applications in AAD that should have Reader access to the environment. The service principal objectId can be obtained by calling the Get-AzureRMADUser or the Get-AzureRMADServicePrincipal cmdlets. Creating an access policy for AAD groups is not yet supported."
+          "description": "A list of object ids of the users or applications in Entra ID that should have Reader access to the environment. The service principal objectId can be obtained by calling the Get-AzureRMADUser or the Get-AzureRMADServicePrincipal cmdlets. Creating an access policy for Entra ID groups is not yet supported."
         }
       },
       "accessPolicyContributorObjectIds": {
         "type": "array",
         "defaultValue": [],
         "metadata": {
-          "description": "A list of object ids of the users or applications in AAD that should have Contributor access to the environment. The service principal objectId can be obtained by calling the Get-AzureRMADUser or the Get-AzureRMADServicePrincipal cmdlets. Creating an access policy for AAD groups is not yet supported."
+          "description": "A list of object ids of the users or applications in Entra ID that should have Contributor access to the environment. The service principal objectId can be obtained by calling the Get-AzureRMADUser or the Get-AzureRMADServicePrincipal cmdlets. Creating an access policy for Entra ID groups is not yet supported."
         }
       },
       "location": {

--- a/components/terraform/digital_twins/variables.tf
+++ b/components/terraform/digital_twins/variables.tf
@@ -25,7 +25,7 @@ variable "eventhub_secondary_connection_string" {
 
 variable "owner_principal_object_id" {
   type        = string
-  description = "Azure AD Object ID of the user to be assigned Azure Digital Twins Data Owner role to."
+  description = "Entra Object ID of the user to be assigned Azure Digital Twins Data Owner role to."
 }
 
 variable "event_hubs_route_filter" {

--- a/components/terraform/time_series_insights/variables.tf
+++ b/components/terraform/time_series_insights/variables.tf
@@ -15,7 +15,7 @@ variable "resource_group" {
 
 variable "reader_principal_object_id" {
   type        = string
-  description = "Azure AD Object ID of the user to be assigned Reader role into the Time Series Insights instance."
+  description = "Entra Object ID of the user to be assigned Reader role into the Time Series Insights instance."
 }
 
 variable "id_properties" {

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -65,7 +65,7 @@ sudo apt install maven
   template](https://azure.microsoft.com/en-us/resources/templates/101-databricks-all-in-one-template-for-vnet-injection/),
   changing the tier to standard on the deployment screen.
 * Install a build agent (instructions below).
-* In Azure AD, create a service principal. Grant the service principal
+* In Microsoft Entra ID, create a service principal. Grant the service principal
   *Owner* permission on your subscription (we can't use the automatic
   service connection dialog in Azure DevOps, as that would only grant
   *Contributor* permissions. We need *Owner* in order to grant Azure Kubernetes


### PR DESCRIPTION
https://learn.microsoft.com/en-us/entra/fundamentals/new-name

Microsoft has renamed Azure Active Directory (Azure AD) to Microsoft Entra ID.